### PR TITLE
Several Optimizations

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,12 @@
  *
  * @package _tk
  */
+ 
+ /**
+  * Store the theme's directory path and uri in constants
+  */
+ define('THEME_DIR_PATH', get_template_directory());
+ define('THEME_DIR_URI', get_template_directory_uri());
 
 /**
  * Set the content width based on the theme's design and stylesheet.
@@ -59,7 +65,7 @@ function _tk_setup() {
 	 * If you're building a theme based on _tk, use a find and replace
 	 * to change '_tk' to the name of your theme in all the template files
 	*/
-	load_theme_textdomain( '_tk', get_template_directory() . '/languages' );
+	load_theme_textdomain( '_tk', THEME_DIR_PATH . '/languages' );
 
 	/**
 	 * This theme uses wp_nav_menu() in one location.
@@ -93,31 +99,31 @@ add_action( 'widgets_init', '_tk_widgets_init' );
 function _tk_scripts() {
 
 	// Import the necessary TK Bootstrap WP CSS additions
-	wp_enqueue_style( '_tk-bootstrap-wp', get_template_directory_uri() . '/includes/css/bootstrap-wp.css' );
+	wp_enqueue_style( '_tk-bootstrap-wp', THEME_DIR_URI . '/includes/css/bootstrap-wp.css' );
 
 	// load bootstrap css
-	wp_enqueue_style( '_tk-bootstrap', get_template_directory_uri() . '/includes/resources/bootstrap/css/bootstrap.min.css' );
+	wp_enqueue_style( '_tk-bootstrap', THEME_DIR_URI . '/includes/resources/bootstrap/css/bootstrap.min.css' );
 
 	// load Font Awesome css
-	wp_enqueue_style( '_tk-font-awesome', get_template_directory_uri() . '/includes/css/font-awesome.min.css', false, '4.1.0' );
+	wp_enqueue_style( '_tk-font-awesome', THEME_DIR_URI . '/includes/css/font-awesome.min.css', false, '4.1.0' );
 
 	// load _tk styles
 	wp_enqueue_style( '_tk-style', get_stylesheet_uri() );
 
 	// load bootstrap js
-	wp_enqueue_script('_tk-bootstrapjs', get_template_directory_uri().'/includes/resources/bootstrap/js/bootstrap.min.js', array('jquery') );
+	wp_enqueue_script('_tk-bootstrapjs', THEME_DIR_URI . '/includes/resources/bootstrap/js/bootstrap.min.js', array('jquery') );
 
 	// load bootstrap wp js
-	wp_enqueue_script( '_tk-bootstrapwp', get_template_directory_uri() . '/includes/js/bootstrap-wp.js', array('jquery') );
+	wp_enqueue_script( '_tk-bootstrapwp', THEME_DIR_URI . '/includes/js/bootstrap-wp.js', array('jquery') );
 
-	wp_enqueue_script( '_tk-skip-link-focus-fix', get_template_directory_uri() . '/includes/js/skip-link-focus-fix.js', array(), '20130115', true );
+	wp_enqueue_script( '_tk-skip-link-focus-fix', THEME_DIR_URI . '/includes/js/skip-link-focus-fix.js', array(), '20130115', true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
 
 	if ( is_singular() && wp_attachment_is_image() ) {
-		wp_enqueue_script( '_tk-keyboard-image-navigation', get_template_directory_uri() . '/includes/js/keyboard-image-navigation.js', array( 'jquery' ), '20120202' );
+		wp_enqueue_script( '_tk-keyboard-image-navigation', THEME_DIR_URI . '/includes/js/keyboard-image-navigation.js', array( 'jquery' ), '20120202' );
 	}
 
 }
@@ -126,32 +132,32 @@ add_action( 'wp_enqueue_scripts', '_tk_scripts' );
 /**
  * Implement the Custom Header feature.
  */
-require get_template_directory() . '/includes/custom-header.php';
+require THEME_DIR_PATH . '/includes/custom-header.php';
 
 /**
  * Custom template tags for this theme.
  */
-require get_template_directory() . '/includes/template-tags.php';
+require THEME_DIR_PATH . '/includes/template-tags.php';
 
 /**
  * Custom functions that act independently of the theme templates.
  */
-require get_template_directory() . '/includes/extras.php';
+require THEME_DIR_PATH . '/includes/extras.php';
 
 /**
  * Customizer additions.
  */
-require get_template_directory() . '/includes/customizer.php';
+require THEME_DIR_PATH . '/includes/customizer.php';
 
 /**
  * Load Jetpack compatibility file.
  */
-require get_template_directory() . '/includes/jetpack.php';
+require THEME_DIR_PATH . '/includes/jetpack.php';
 
 /**
  * Load custom WordPress nav walker.
  */
-require get_template_directory() . '/includes/bootstrap-wp-navwalker.php';
+require THEME_DIR_PATH . '/includes/bootstrap-wp-navwalker.php';
 
 /**
  * Adds WooCommerce support


### PR DESCRIPTION
Using get_template_directory() or get_template_directory_uri() produces 14 more SQL queries in worst case. 
Why not we store the theme path in constant instead of calling those functions multiple times in one request.

This won't be a lot noticeable but it will save some resources on critical environments.